### PR TITLE
Prepare v1.2.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.2.6 [2026-03-19]
+- fix _unescape skipping entire list when any element is blank
+- fix merge_facets dropping duplicate-key facets via dict() overwrite
+- fix SORT regex to match underscore/digit field names
+- replace deprecated response.code with response.status
+
 1.2.5 [2026-03-19]
 - fix get_facets() returning {} instead of [] on no-facet path
 - remove dead data_format=None guard in scroll_get_query and stream_get_query

--- a/txpyfind/cli.py
+++ b/txpyfind/cli.py
@@ -24,10 +24,10 @@ def parse_facet(value):
 
 
 def merge_facets(facet_list):
-    """Merge a list of (key, value) tuples into a single dict."""
+    """Convert a list of (key, value) tuples into a list of single-key dicts."""
     if not facet_list:
         return None
-    return dict(facet_list)
+    return [{k: v} for k, v in facet_list]
 
 
 def build_parser():

--- a/txpyfind/parser.py
+++ b/txpyfind/parser.py
@@ -39,6 +39,6 @@ class JSONResponse:  # pylint: disable=R0903
         if isinstance(value, str):
             return html.unescape(value.strip())
         if isinstance(value, list) and len(value) > 0 and \
-                all(isinstance(v, str) and len(v.strip()) > 0 for v in value):
+                all(isinstance(v, str) for v in value):
             return [html.unescape(v.strip()) for v in value]
         return value

--- a/txpyfind/urlparse.py
+++ b/txpyfind/urlparse.py
@@ -10,7 +10,7 @@ SUBSTITUTE = "%#"
 FACET = re.compile(r"tx_find_find\[facet\]\[([^]]*)\]\[([^]]*)\]=1&?")
 PAGE = re.compile(r"tx_find_find\[page\]=(\d*)&?")
 COUNT = re.compile(r"tx_find_find\[count\]=(\d*)&?")
-SORT = re.compile(r"tx_find_find\[sort\]=([a-zA-Z]*)[+ ]([a-zA-Z]*)&?")
+SORT = re.compile(r"tx_find_find\[sort\]=([a-zA-Z0-9_]*)[+ ]([a-zA-Z0-9_]*)&?")
 
 
 class URLParser:  # pylint: disable=R0902,R0903

--- a/txpyfind/utils.py
+++ b/txpyfind/utils.py
@@ -21,9 +21,9 @@ def get_request(url):
     req.add_header("User-Agent", f"txpyfind {__version__}")
     try:
         with urlopen(req) as response:
-            if response.code == 200:
+            if response.status == 200:
                 return response.read()
-            logger.error("HTTP %d GET %s", response.code, url)
+            logger.error("HTTP %d GET %s", response.status, url)
     except URLError as exc:
         logger.error("Failed to fetch %s: %s", url, exc)
     return None


### PR DESCRIPTION
Four correctness and forward-compatibility fixes.

- parser.py: _unescape no longer skips HTML unescaping of an entire list when any element is blank — the
blank-string guard len(v.strip()) > 0 has been removed
- cli.py: merge_facets now returns a list of single-key dicts instead of a flat dict, so repeated --facet keys (e.g.
  --facet type=book --facet type=article) are no longer silently dropped
- urlparse.py: the SORT regex now matches field names containing underscores and digits (e.g. score_sort asc,
pub_date desc)
- utils.py: replaced deprecated response.code with response.status