### PR TITLE
Prepare v1.2.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.2.7 [2026-03-19]
+- add 30-second timeout to urlopen to prevent indefinite blocking
+- initialise URLParser.query and URLParser.qtype to "" unconditionally
+
 1.2.6 [2026-03-19]
 - fix _unescape skipping entire list when any element is blank
 - fix merge_facets dropping duplicate-key facets via dict() overwrite

--- a/txpyfind/urlparse.py
+++ b/txpyfind/urlparse.py
@@ -20,6 +20,8 @@ class URLParser:  # pylint: disable=R0902,R0903
 
     def __init__(self, url):
         self.url = url
+        self.query = ""
+        self.qtype = ""
         query_details = get_query(url)
         self.is_ok = False
         if len(query_details) > 1:

--- a/txpyfind/utils.py
+++ b/txpyfind/utils.py
@@ -20,7 +20,7 @@ def get_request(url):
     req = Request(url)
     req.add_header("User-Agent", f"txpyfind {__version__}")
     try:
-        with urlopen(req) as response:
+        with urlopen(req, timeout=30) as response:
             if response.status == 200:
                 return response.read()
             logger.error("HTTP %d GET %s", response.status, url)


### PR DESCRIPTION
## Summary

- Add 30-second timeout to `urlopen` in `utils.py` — prevents the client from blocking indefinitely if the server hangs
- Initialise `URLParser.query` and `URLParser.qtype` to `""` unconditionally in `urlparse.py` — removes a latent `AttributeError` if either attribute is accessed when `is_ok` is `False`
