### PR TITLE
Prepare v1.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.3.0 [2026-03-21]
+- add RawSolrResponse, SolrResultsResponse, AllResponse parser classes
+- refactor scroll_get_query and stream_get_query to use RawSolrResponse
+
 1.2.8 [2026-03-19]
 - fix document examples in README to use json-ld export format
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,0 +1,144 @@
+"""
+Offline unit tests for txpyfind.parser classes.
+"""
+import json
+import pytest
+from txpyfind.parser import (
+    JSONResponse,
+    RawSolrResponse,
+    SolrResultsResponse,
+    AllResponse,
+)
+
+
+# --- JSONResponse ---
+
+class TestJSONResponse:
+
+    def test_valid_dict(self):
+        data = {"key": "value", "count": 42}
+        r = JSONResponse(json.dumps(data))
+        assert r.raw == data
+        assert r.fields == ["key", "count"]
+
+    def test_valid_list(self):
+        data = [{"a": 1}, {"b": 2}]
+        r = JSONResponse(json.dumps(data))
+        assert r.raw == data
+        assert r.fields == []
+
+    def test_invalid_json(self):
+        r = JSONResponse("not json")
+        assert r.raw is None
+        assert r.fields == []
+
+    def test_html_unescaping(self):
+        data = {"title": "foo &amp; bar"}
+        r = JSONResponse(json.dumps(data))
+        assert r._field("title") == "foo & bar"
+
+    def test_html_unescaping_list(self):
+        data = {"tags": ["a &amp; b", "c &lt; d"]}
+        r = JSONResponse(json.dumps(data))
+        assert r._field("tags") == ["a & b", "c < d"]
+
+
+# --- RawSolrResponse ---
+
+class TestRawSolrResponse:
+
+    def _make(self, response=None, **extra):
+        data = {}
+        if response is not None:
+            data["response"] = response
+        data.update(extra)
+        return RawSolrResponse(json.dumps(data))
+
+    def test_valid_response(self):
+        docs = [{"id": "1"}, {"id": "2"}]
+        r = self._make(response={"numFound": 2, "start": 0, "docs": docs})
+        assert r.ok is True
+        assert r.num_found == 2
+        assert r.start == 0
+        assert r.docs == docs
+
+    def test_missing_response_key(self):
+        r = RawSolrResponse(json.dumps({"other": "data"}))
+        assert r.ok is False
+        assert r.num_found == 0
+        assert r.docs == []
+
+    def test_empty_docs(self):
+        r = self._make(response={"numFound": 0, "start": 0, "docs": []})
+        assert r.ok is True
+        assert r.num_found == 0
+        assert r.docs == []
+
+    def test_facet_counts(self):
+        facets = {"facet_fields": {"type": ["book", 10]}}
+        r = self._make(
+            response={"numFound": 0, "start": 0, "docs": []},
+            facet_counts=facets)
+        assert r.facet_counts == facets
+
+    def test_facet_counts_missing(self):
+        r = self._make(response={"numFound": 0, "start": 0, "docs": []})
+        assert r.facet_counts is None
+
+    def test_highlighting(self):
+        hl = {"doc1": {"title": ["<em>test</em>"]}}
+        r = self._make(
+            response={"numFound": 0, "start": 0, "docs": []},
+            highlighting=hl)
+        assert r.highlighting == hl
+
+    def test_highlighting_missing(self):
+        r = self._make(response={"numFound": 0, "start": 0, "docs": []})
+        assert r.highlighting is None
+
+    def test_raw_and_fields_available(self):
+        r = self._make(response={"numFound": 0, "start": 0, "docs": []})
+        assert isinstance(r.raw, dict)
+        assert "response" in r.fields
+
+
+# --- SolrResultsResponse ---
+
+class TestSolrResultsResponse:
+
+    def test_valid_list(self):
+        data = [{"id": "1", "title": "A"}, {"id": "2", "title": "B"}]
+        r = SolrResultsResponse(json.dumps(data))
+        assert r.ok is True
+        assert r.docs == data
+
+    def test_empty_list(self):
+        r = SolrResultsResponse(json.dumps([]))
+        assert r.ok is True
+        assert r.docs == []
+
+    def test_non_list_input(self):
+        r = SolrResultsResponse(json.dumps({"key": "value"}))
+        assert r.ok is False
+        assert r.docs == []
+
+
+# --- AllResponse ---
+
+class TestAllResponse:
+
+    def test_valid_with_settings(self):
+        data = {"settings": {"lang": "de"}, "other": "x"}
+        r = AllResponse(json.dumps(data))
+        assert r.ok is True
+        assert r.settings == {"lang": "de"}
+
+    def test_missing_settings(self):
+        r = AllResponse(json.dumps({"other": "data"}))
+        assert r.ok is True
+        assert r.settings is None
+
+    def test_non_dict_input(self):
+        r = AllResponse(json.dumps([1, 2, 3]))
+        assert r.ok is False
+        assert r.settings is None

--- a/txpyfind/client.py
+++ b/txpyfind/client.py
@@ -4,7 +4,7 @@ client module of ``txpyfind`` package
 import re
 import logging
 from . import utils
-from .parser import JSONResponse
+from .parser import JSONResponse, RawSolrResponse
 from .urlparse import URLParser
 
 
@@ -245,6 +245,8 @@ class Find:  # pylint: disable=R0902
             self.logger.warning(
                 "Scrolling only supports data format of type 'raw-solr-response'!")
             data_format = "raw-solr-response"
+        if parser_class is None:
+            parser_class = RawSolrResponse
         response = self.get_query(
             query,
             qtype=qtype,
@@ -253,10 +255,8 @@ class Find:  # pylint: disable=R0902
             data_format=data_format,
             type_num=type_num,
             parser_class=parser_class)
-        if hasattr(response, "raw") and isinstance(
-                response.raw, dict) and "response" in response.raw:
-            data = response.raw["response"]
-            total = data["numFound"]
+        if isinstance(response, RawSolrResponse) and response.ok:
+            total = response.num_found
             docs = []
             pages = int(total / batch) + (total % batch > 0)
             for i in range(1, pages+1):
@@ -270,12 +270,8 @@ class Find:  # pylint: disable=R0902
                     data_format=data_format,
                     type_num=type_num,
                     parser_class=parser_class)
-                if hasattr(response_i, "raw") and isinstance(
-                        response_i.raw, dict) and "response" in response_i.raw:
-                    data_i = response_i.raw["response"]
-                    if "docs" in data_i:
-                        for doc in data_i["docs"]:
-                            docs.append(doc)
+                if isinstance(response_i, RawSolrResponse) and response_i.ok:
+                    docs.extend(response_i.docs)
             found = len(docs)
             if total != found:
                 self.logger.warning(
@@ -304,6 +300,8 @@ class Find:  # pylint: disable=R0902
             self.logger.warning(
                 "Streaming only supports data format of type 'raw-solr-response'!")
             data_format = "raw-solr-response"
+        if parser_class is None:
+            parser_class = RawSolrResponse
         response = self.get_query(
             query,
             qtype=qtype,
@@ -312,10 +310,8 @@ class Find:  # pylint: disable=R0902
             data_format=data_format,
             type_num=type_num,
             parser_class=parser_class)
-        if hasattr(response, "raw") and isinstance(
-                response.raw, dict) and "response" in response.raw:
-            data = response.raw["response"]
-            total = data["numFound"]
+        if isinstance(response, RawSolrResponse) and response.ok:
+            total = response.num_found
             pages = int(total / batch) + (total % batch > 0)
             for i in range(1, pages+1):
                 response_i = self.get_query(
@@ -328,8 +324,5 @@ class Find:  # pylint: disable=R0902
                     data_format=data_format,
                     type_num=type_num,
                     parser_class=parser_class)
-                if hasattr(response_i, "raw") and isinstance(
-                        response_i.raw, dict) and "response" in response_i.raw:
-                    data_i = response_i.raw["response"]
-                    if "docs" in data_i:
-                        yield from data_i["docs"]
+                if isinstance(response_i, RawSolrResponse) and response_i.ok:
+                    yield from response_i.docs

--- a/txpyfind/parser.py
+++ b/txpyfind/parser.py
@@ -42,3 +42,74 @@ class JSONResponse:  # pylint: disable=R0903
                 all(isinstance(v, str) for v in value):
             return [html.unescape(v.strip()) for v in value]
         return value
+
+
+class RawSolrResponse(JSONResponse):
+    """
+    Parser for ``raw-solr-response`` export format.
+
+    Expected structure::
+
+        {"response": {"numFound": N, "start": S, "docs": [...]},
+         "facet_counts": {...}, "highlighting": {...}}
+    """
+
+    def __init__(self, plain):
+        super().__init__(plain)
+        response = self._field("response")
+        if isinstance(response, dict):
+            self.ok = True
+            self.num_found = response.get("numFound", 0)
+            self.start = response.get("start", 0)
+            self.docs = response.get("docs", [])
+        else:
+            self.ok = False
+            self.num_found = 0
+            self.start = 0
+            self.docs = []
+
+    @property
+    def facet_counts(self):
+        return self._field("facet_counts")
+
+    @property
+    def highlighting(self):
+        return self._field("highlighting")
+
+
+class SolrResultsResponse(JSONResponse):
+    """
+    Parser for ``json-solr-results`` export format.
+
+    Expected structure::
+
+        [{field1: ..., field2: ...}, ...]
+    """
+
+    def __init__(self, plain):
+        super().__init__(plain)
+        self.ok = isinstance(self.raw, list)
+
+    @property
+    def docs(self):
+        if self.ok:
+            return self.raw
+        return []
+
+
+class AllResponse(JSONResponse):
+    """
+    Parser for ``json-all`` export format.
+
+    Expected structure::
+
+        {"settings": {...}, ...}
+    """
+
+    def __init__(self, plain):
+        super().__init__(plain)
+        self.ok = isinstance(self.raw, dict)
+
+    @property
+    def settings(self):
+        return self._field("settings")


### PR DESCRIPTION
## Summary
- Add `RawSolrResponse`, `SolrResultsResponse`, and `AllResponse` parser classes for the three TYPO3-find export formats
- Refactor `scroll_get_query` and `stream_get_query` to use `RawSolrResponse` internally
- Add offline unit tests for all parser classes

## Test plan
- [x] `python -m pytest test/test_parser.py` — 19 offline parser tests pass
- [x] `python -m pytest test/` — all 23 tests pass (including integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)