### PR TITLE
Move subcommand-specific CLI flags to their subcommands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+1.4.0 [2026-03-21]
+- move --export-format to query (with choices) and document (required) subcommands
+- move --pretty to query and document subcommands
+- move --document-path to document subcommand
+- consolidate --type, --facet, --sort into shared query/scroll parent parser
+- move --query-type, --count-limit, --sort-pattern to query and scroll subcommands
+- scroll output is always compact JSON
+
 1.3.0 [2026-03-21]
 - add RawSolrResponse, SolrResultsResponse, AllResponse parser classes
 - refactor scroll_get_query and stream_get_query to use RawSolrResponse

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ is allowed:
 
 .. code-block:: bash
 
-   txpyfind --url https://katalog.slub-dresden.de --query-type default --query-type author --query-type title query "bonitz" --type author
+   txpyfind --url https://katalog.slub-dresden.de query --query-type default --query-type author --query-type title --type author "bonitz"
 
 Document
 ~~~~~~~~
@@ -80,7 +80,7 @@ Fetch a single document by ID:
 
 .. code-block:: bash
 
-   txpyfind --url https://katalog.slub-dresden.de --document-path id --export-format json-ld document 0-1132486122
+   txpyfind --url https://katalog.slub-dresden.de document --document-path id --export-format json-ld 0-1132486122
 
 Scroll
 ~~~~~~
@@ -106,20 +106,21 @@ This works with all subcommands:
 .. code-block:: bash
 
    txpyfind --url https://katalog.slub-dresden.de --show-url query "python" --facet format_de14="Book, E-Book"
-   txpyfind --url https://katalog.slub-dresden.de --document-path id --export-format json-ld --show-url document 0-1132486122
+   txpyfind --url https://katalog.slub-dresden.de --show-url document --document-path id --export-format json-ld 0-1132486122
    txpyfind --url https://katalog.slub-dresden.de --show-url scroll "python" --batch 10
 
 Export Format
 ~~~~~~~~~~~~~
 
-Use ``--export-format`` to select the response format. The three formats
-built into TYPO3-find are ``raw-solr-response`` (default), ``json-all``, and
-``json-solr-results``. Individual instances may provide additional formats:
+Use ``--export-format`` on the ``query`` subcommand to select the response
+format (default: ``raw-solr-response``). On the ``document`` subcommand,
+``--export-format`` is required and has no default. The three formats built
+into TYPO3-find are ``raw-solr-response``, ``json-all``, and
+``json-solr-results``:
 
 .. code-block:: bash
 
-   txpyfind --url https://katalog.slub-dresden.de --export-format json-solr-results query "manfred bonitz"
-   txpyfind --url https://katalog.slub-dresden.de --document-path id --export-format json-ld document 0-1132486122
+   txpyfind --url https://katalog.slub-dresden.de query --export-format json-solr-results "manfred bonitz"
 
 Environment Variable
 ~~~~~~~~~~~~~~~~~~~~
@@ -130,7 +131,7 @@ Set ``TXPYFIND_URL`` to avoid repeating the ``--url`` option:
 
    export TXPYFIND_URL=https://katalog.slub-dresden.de
    txpyfind query "manfred bonitz"
-   txpyfind --document-path id --export-format json-ld document 0-1132486122
+   txpyfind document --document-path id --export-format json-ld 0-1132486122
 
 Python Usage Example
 ====================

--- a/txpyfind/cli.py
+++ b/txpyfind/cli.py
@@ -45,36 +45,10 @@ def build_parser():
         help="base URL of the TYPO3-find instance"
              " (or set TXPYFIND_URL env var)")
     parser.add_argument(
-        "--document-path",
-        default=None,
-        help="document path for detail views")
-    parser.add_argument(
-        "--query-type",
-        action="append",
-        dest="query_types",
-        help="allowed query type (repeatable, default: 'default')")
-    parser.add_argument(
-        "--export-format",
-        default="raw-solr-response",
-        help="export format (default: raw-solr-response)")
-    parser.add_argument(
         "--export-page",
         type=int,
         default=1369315139,
         help="export page type number (default: 1369315139)")
-    parser.add_argument(
-        "--count-limit",
-        type=int,
-        default=100,
-        help="maximum count per request (default: 100)")
-    parser.add_argument(
-        "--sort-pattern",
-        default=None,
-        help="regex pattern for allowed sort instructions")
-    parser.add_argument(
-        "--pretty",
-        action="store_true",
-        help="pretty-print JSON output (default: compact)")
     parser.add_argument(
         "--show-url",
         action="store_true",
@@ -84,48 +58,80 @@ def build_parser():
         action="store_true",
         help="enable debug logging to stderr")
 
+    # shared options for query-based subcommands
+    query_common = argparse.ArgumentParser(add_help=False)
+    query_common.add_argument(
+        "--query-type",
+        action="append",
+        dest="query_types",
+        help="allowed query type (repeatable, default: 'default')")
+    query_common.add_argument(
+        "--count-limit",
+        type=int,
+        default=100,
+        help="maximum count per request (default: 100)")
+    query_common.add_argument(
+        "--sort-pattern",
+        default=None,
+        help="regex pattern for allowed sort instructions")
+    query_common.add_argument(
+        "--type", default="default",
+        help="query type; must be one of the --query-type values (default: default)")
+    query_common.add_argument(
+        "--facet", action="append", type=parse_facet,
+        help="facet filter as KEY=VALUE (repeatable)")
+    query_common.add_argument(
+        "--sort", default="", help="sort instruction")
+
     subparsers = parser.add_subparsers(dest="command")
 
     # query subcommand
     query_parser = subparsers.add_parser(
-        "query", help="execute a search query")
+        "query", help="execute a search query",
+        parents=[query_common])
     query_parser.add_argument("query", help="search query string")
     query_parser.add_argument(
-        "--type", default="default",
-        help="query type; must be one of the --query-type values (default: default)")
+        "--export-format",
+        choices=["raw-solr-response", "json-solr-results", "json-all"],
+        default="raw-solr-response",
+        help="export format (default: raw-solr-response)")
     query_parser.add_argument(
-        "--facet", action="append", type=parse_facet,
-        help="facet filter as KEY=VALUE (repeatable)")
+        "--pretty",
+        action="store_true",
+        help="pretty-print JSON output")
     query_parser.add_argument(
         "--page", type=int, default=0, help="page number")
     query_parser.add_argument(
         "--count", type=int, default=0, help="results per page")
-    query_parser.add_argument(
-        "--sort", default="", help="sort instruction")
+
+    # scroll subcommand
+    scroll_parser = subparsers.add_parser(
+        "scroll", help="fetch all paginated results",
+        parents=[query_common])
+    scroll_parser.add_argument("query", help="search query string")
+    scroll_parser.add_argument(
+        "--batch", type=int, default=20,
+        help="results per batch (default: 20)")
+    scroll_parser.add_argument(
+        "--stream", action="store_true",
+        help="output one JSON object per line (JSONL)")
 
     # document subcommand
     doc_parser = subparsers.add_parser(
         "document", help="fetch a document by ID")
     doc_parser.add_argument("document_id", help="document identifier")
-
-    # scroll subcommand
-    scroll_parser = subparsers.add_parser(
-        "scroll", help="fetch all paginated results")
-    scroll_parser.add_argument("query", help="search query string")
-    scroll_parser.add_argument(
-        "--type", default="default",
-        help="query type; must be one of the --query-type values (default: default)")
-    scroll_parser.add_argument(
-        "--facet", action="append", type=parse_facet,
-        help="facet filter as KEY=VALUE (repeatable)")
-    scroll_parser.add_argument(
-        "--batch", type=int, default=20,
-        help="results per batch (default: 20)")
-    scroll_parser.add_argument(
-        "--sort", default="", help="sort instruction")
-    scroll_parser.add_argument(
-        "--stream", action="store_true",
-        help="output one JSON object per line (JSONL)")
+    doc_parser.add_argument(
+        "--document-path",
+        default=None,
+        help="document path for detail views")
+    doc_parser.add_argument(
+        "--export-format",
+        required=True,
+        help="export format (required for document subcommand)")
+    doc_parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="pretty-print JSON output")
 
     return parser
 
@@ -138,20 +144,21 @@ def make_find(args):
         sys.exit(1)
 
     sort_pattern = None
-    if args.sort_pattern is not None:
-        sort_pattern = re.compile(args.sort_pattern)
+    raw_sort_pattern = getattr(args, 'sort_pattern', None)
+    if raw_sort_pattern is not None:
+        sort_pattern = re.compile(raw_sort_pattern)
 
-    query_types = args.query_types
+    query_types = getattr(args, 'query_types', None)
     if query_types is None:
         query_types = ["default"]
 
     return Find(
         args.url,
-        document_path=args.document_path,
+        document_path=getattr(args, 'document_path', None),
         query_types=query_types,
-        count_limit=args.count_limit,
+        count_limit=getattr(args, 'count_limit', 100),
         sort_pattern=sort_pattern,
-        export_format=args.export_format,
+        export_format=getattr(args, 'export_format', 'raw-solr-response'),
         export_page=args.export_page)
 
 
@@ -227,7 +234,7 @@ def cmd_scroll(find, args):
                 facet=merge_facets(args.facet),
                 batch=args.batch,
                 sort=args.sort):
-            print(json_dumps(doc, pretty=args.pretty))
+            print(json_dumps(doc))
         return 0
 
     results = find.scroll_get_query(
@@ -239,7 +246,7 @@ def cmd_scroll(find, args):
     if results is None:
         print("error: no results", file=sys.stderr)
         return 1
-    print(json_dumps(results, pretty=args.pretty))
+    print(json_dumps(results))
     return 0
 
 


### PR DESCRIPTION
## Summary
- Move `--export-format` to `query` subcommand (with choices validation)
- Move `--pretty` to `query` and `document` subcommands
- Move `--document-path` to `document` subcommand
- Move `--query-type`, `--count-limit`, `--sort-pattern` to `query` and `scroll` subcommands (via shared parent parser)
- Scroll output is always compact JSON
- Update README examples to reflect new flag positions

## Test plan
- [x] All 23 existing tests pass
- [x] Flags work after subcommand name
- [x] Old flag positions correctly error
- [x] `--show-url` with document subcommand works

🤖 Generated with [Claude Code](https://claude.com/claude-code)