### PR TITLE
Prepare v1.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+1.5.0 [2026-03-21]
+- add --plain flag to print raw response text
+- add --parser flag to load custom parser classes from the CLI
+- add --parser none to disable parsing and print raw response
+- remove --export-format choices restriction on query subcommand
+- rewrite README intro, add plain output and custom parser sections
+- normalize docstrings across all modules
+- update package description in pyproject.toml
+
 1.4.0 [2026-03-21]
 - move --export-format to query (with choices) and document (required) subcommands
 - move --pretty to query and document subcommands

--- a/README.rst
+++ b/README.rst
@@ -2,20 +2,23 @@
 txpyfind
 ========
 
-``txpyfind`` enables access to data exports from `TYPO3-find <https://github.com/subugoe/typo3-find>`_
-in Python. Details on the TYPO3-find setup required for data exports can be found in the section
-`Data export <https://github.com/subugoe/typo3-find#data-export>`_ in the README file of that repository.
+``txpyfind`` is a Python client and CLI for querying
+`TYPO3-find <https://github.com/subugoe/typo3-find>`_
+(Solr-based search) instances. It builds URLs with
+TYPO3-find-specific query parameters, fetches responses,
+and parses them.
 
-The three JSON formats ``json-all``, ``json-solr-results`` and ``raw-solr-response`` are already available
-in the TYPO3 extension, see the
-`partials <https://github.com/subugoe/typo3-find/tree/main/Resources/Private/Partials/Formats>`_ used
-to create the three formats.
+Three parser classes are included for the native
+TYPO3-find data formats: ``RawSolrResponse``
+(``raw-solr-response``), ``SolrResultsResponse``
+(``json-solr-results``), and ``AllResponse``
+(``json-all``). Custom parser classes can be passed
+to the client for any other format. The plain response
+text is always available via the ``.plain`` attribute.
 
-You can use the client class available in this Python package to query these exports. A simple parser
-for the returned JSON objects is also available.
-
-See `slubfind <https://github.com/slub/slubfind>`_ for a real-world implementation example,
-including custom query types and instance-specific response parsing.
+See `slubfind <https://github.com/slub/slubfind>`_
+for a real-world implementation with custom query
+types and instance-specific response parsing.
 
 Installation
 ============
@@ -106,7 +109,13 @@ This works with all subcommands:
 .. code-block:: bash
 
    txpyfind --url https://katalog.slub-dresden.de --show-url query "python" --facet format_de14="Book, E-Book"
+
+.. code-block:: bash
+
    txpyfind --url https://katalog.slub-dresden.de --show-url document --document-path id --export-format json-ld 0-1132486122
+
+.. code-block:: bash
+
    txpyfind --url https://katalog.slub-dresden.de --show-url scroll "python" --batch 10
 
 Export Format
@@ -116,11 +125,45 @@ Use ``--export-format`` on the ``query`` subcommand to select the response
 format (default: ``raw-solr-response``). On the ``document`` subcommand,
 ``--export-format`` is required and has no default. The three formats built
 into TYPO3-find are ``raw-solr-response``, ``json-all``, and
-``json-solr-results``:
+``json-solr-results``, but any format string accepted by the instance can
+be used:
 
 .. code-block:: bash
 
    txpyfind --url https://katalog.slub-dresden.de query --export-format json-solr-results "manfred bonitz"
+
+Plain Output
+~~~~~~~~~~~~
+
+Use ``--plain`` to print the raw response text instead of parsed JSON output.
+This works with the ``query`` and ``document`` subcommands:
+
+.. code-block:: bash
+
+   txpyfind --url https://katalog.slub-dresden.de --plain query "manfred bonitz"
+
+.. code-block:: bash
+
+   txpyfind --url https://katalog.slub-dresden.de --plain document --document-path id --export-format json-ld 0-1132486122
+
+Custom Parser
+~~~~~~~~~~~~~
+
+Use ``--parser`` to load a custom parser class by its dotted import path.
+This allows packages built on top of ``txpyfind`` (like ``slubfind``) to
+use their own response parsing from the CLI. The class must accept a plain
+text string as its constructor argument and provide a ``.raw`` attribute
+with JSON-serializable data (and a ``.plain`` attribute for ``--plain``).
+Use ``--parser none`` to disable parsing entirely and print the raw
+response text:
+
+.. code-block:: bash
+
+   txpyfind --url https://katalog.slub-dresden.de --parser slubfind.parser.FincSolrResponse query "manfred bonitz"
+
+.. code-block:: bash
+
+   txpyfind --url https://katalog.slub-dresden.de --parser none query "manfred bonitz"
 
 Environment Variable
 ~~~~~~~~~~~~~~~~~~~~
@@ -130,7 +173,13 @@ Set ``TXPYFIND_URL`` to avoid repeating the ``--url`` option:
 .. code-block:: bash
 
    export TXPYFIND_URL=https://katalog.slub-dresden.de
+
+.. code-block:: bash
+
    txpyfind query "manfred bonitz"
+
+.. code-block:: bash
+
    txpyfind document --document-path id --export-format json-ld 0-1132486122
 
 Python Usage Example
@@ -149,6 +198,19 @@ Python Usage Example
    slub_find.get_query("python", facet={"format_de14": "Book, E-Book"})
    # query with multiple facets (list of dicts)
    slub_find.get_query("python", facet=[{"format_de14": "Book, E-Book"}, {"language": "German"}])
+
+   # access the plain response text
+   result = slub_find.get_query("manfred bonitz")
+   print(result.plain)
+
+   # use a specific built-in parser
+   from txpyfind.parser import RawSolrResponse
+   result = slub_find.get_query("manfred bonitz", parser_class=RawSolrResponse)
+   print(result.num_found, result.docs)
+
+   # use a custom parser class from another package
+   from slubfind.parser import FincSolrResponse
+   slub_find = Find("https://katalog.slub-dresden.de", parser_class=FincSolrResponse)
 
 License
 =======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "txpyfind"
-description = "enables Pythonic access to data exports from TYPO3-find"
+description = "Python client for querying TYPO3-find (Solr-based search) instances"
 readme = "README.rst"
 authors = [
         {name = "Donatus Herre"},

--- a/txpyfind/__init__.py
+++ b/txpyfind/__init__.py
@@ -1,6 +1,4 @@
-"""
-With ``txpyfind`` you can access data exports from TYPO3-find.
-"""
+"""Python client for querying TYPO3-find (Solr-based search) instances."""
 from ._version import __version__, version, version_tuple
 from . import client, parser
 

--- a/txpyfind/cli.py
+++ b/txpyfind/cli.py
@@ -1,7 +1,6 @@
-"""
-command-line interface of ``txpyfind`` package
-"""
+"""Command-line interface for txpyfind."""
 import argparse
+import importlib
 import json
 import logging
 import os
@@ -30,6 +29,27 @@ def merge_facets(facet_list):
     return [{k: v} for k, v in facet_list]
 
 
+def resolve_parser_class(dotted_path):
+    """Import and return a class from a dotted path, or None for 'none'."""
+    if dotted_path.lower() == "none":
+        return "none"
+    module_path, _, class_name = dotted_path.rpartition(".")
+    if not module_path:
+        raise argparse.ArgumentTypeError(
+            f"parser must be a dotted path like 'package.module.Class'"
+            f" or 'none', got: {dotted_path}")
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise argparse.ArgumentTypeError(
+            f"could not import module '{module_path}': {exc}") from exc
+    try:
+        return getattr(module, class_name)
+    except AttributeError:
+        raise argparse.ArgumentTypeError(
+            f"module '{module_path}' has no class '{class_name}'")
+
+
 def build_parser():
     """Build and return the argument parser."""
     parser = argparse.ArgumentParser(
@@ -53,6 +73,21 @@ def build_parser():
         "--show-url",
         action="store_true",
         help="print the request URL instead of fetching the response")
+    parser.add_argument(
+        "--plain",
+        action="store_true",
+        help="print the plain response text instead of parsed output")
+    parser.add_argument(
+        "--parser",
+        type=resolve_parser_class,
+        default=None,
+        metavar="CLASS",
+        help="dotted import path of a custom parser class"
+             " (e.g. 'slubfind.parser.FincSolrResponse'),"
+             " or 'none' to disable parsing and print the raw"
+             " response; custom classes must accept a plain text"
+             " string as constructor argument and provide a .raw"
+             " attribute with JSON-serializable data")
     parser.add_argument(
         "-v", "--verbose",
         action="store_true",
@@ -92,7 +127,6 @@ def build_parser():
     query_parser.add_argument("query", help="search query string")
     query_parser.add_argument(
         "--export-format",
-        choices=["raw-solr-response", "json-solr-results", "json-all"],
         default="raw-solr-response",
         help="export format (default: raw-solr-response)")
     query_parser.add_argument(
@@ -152,6 +186,12 @@ def make_find(args):
     if query_types is None:
         query_types = ["default"]
 
+    kwargs = {}
+    if args.parser == "none":
+        kwargs["parser_class"] = None
+    elif args.parser is not None:
+        kwargs["parser_class"] = args.parser
+
     return Find(
         args.url,
         document_path=getattr(args, 'document_path', None),
@@ -159,7 +199,8 @@ def make_find(args):
         count_limit=getattr(args, 'count_limit', 100),
         sort_pattern=sort_pattern,
         export_format=getattr(args, 'export_format', 'raw-solr-response'),
-        export_page=args.export_page)
+        export_page=args.export_page,
+        **kwargs)
 
 
 def json_dumps(obj, pretty=False):
@@ -190,6 +231,12 @@ def cmd_query(find, args):
     if result is None:
         print("error: no results", file=sys.stderr)
         return 1
+    if isinstance(result, str):
+        print(result)
+        return 0
+    if args.plain:
+        print(result.plain if hasattr(result, "plain") else result)
+        return 0
     data = result.raw if hasattr(result, "raw") else result
     print(json_dumps(data, pretty=args.pretty))
     return 0
@@ -212,6 +259,12 @@ def cmd_document(find, args):
     if result is None:
         print("error: document not found", file=sys.stderr)
         return 1
+    if isinstance(result, str):
+        print(result)
+        return 0
+    if args.plain:
+        print(result.plain if hasattr(result, "plain") else result)
+        return 0
     data = result.raw if hasattr(result, "raw") else result
     print(json_dumps(data, pretty=args.pretty))
     return 0

--- a/txpyfind/client.py
+++ b/txpyfind/client.py
@@ -1,6 +1,4 @@
-"""
-client module of ``txpyfind`` package
-"""
+"""TYPO3-find client for building queries and fetching responses."""
 import re
 import logging
 from . import utils
@@ -9,9 +7,7 @@ from .urlparse import URLParser
 
 
 class Find:  # pylint: disable=R0902
-    """
-    ``Find`` class from ``txpyfind.client`` module
-    """
+    """Client for querying TYPO3-find instances."""
 
     def __init__(  # pylint: disable=R0913,R0917
             self,
@@ -24,6 +20,7 @@ class Find:  # pylint: disable=R0902
             export_format="raw-solr-response",
             export_page=1369315139,
             parser_class=JSONResponse):
+        """Initialize client with base URL and optional query/export settings."""
         self.base_url = base_url
         self.document_path = document_path
         if query_types is None:
@@ -45,9 +42,7 @@ class Find:  # pylint: disable=R0902
             url,
             data_format=None,
             type_num=None):
-        """
-        add data exports parameters as initial parameters to given URL
-        """
+        """Add data export parameters as initial parameters to the given URL."""
         if data_format is None:
             data_format = self.export_format
         if type_num is None:
@@ -62,9 +57,7 @@ class Find:  # pylint: disable=R0902
             url,
             data_format=None,
             type_num=None):
-        """
-        add data exports parameters as subsequent parameters to given URL
-        """
+        """Add data export parameters as subsequent parameters to the given URL."""
         if data_format is None:
             data_format = self.export_format
         if type_num is None:
@@ -78,9 +71,7 @@ class Find:  # pylint: disable=R0902
             self,
             url,
             facet=None):
-        """
-        add facet parameters as subsequent parameters to given URL
-        """
+        """Add facet parameters as subsequent parameters to the given URL."""
         if facet is None:
             return url
         if isinstance(facet, dict):
@@ -94,6 +85,7 @@ class Find:  # pylint: disable=R0902
         return url
 
     def url_parser(self, url):
+        """Return a URLParser for the given URL."""
         return URLParser(url)
 
     def url_document(
@@ -101,9 +93,7 @@ class Find:  # pylint: disable=R0902
             doc_id,
             data_format=None,
             type_num=None):
-        """
-        get the URL for the detail view of the document given by id
-        """
+        """Build the URL for the detail view of the given document."""
         if self.document_url is not None:
             doc_url = f"{self.document_url}/{doc_id}"
             return self.set_data_params(
@@ -118,9 +108,7 @@ class Find:  # pylint: disable=R0902
             data_format=None,
             type_num=None,
             parser_class=None):
-        """
-        get the detail view of the document given by id
-        """
+        """Fetch and parse the detail view of the given document."""
         url = self.url_document(
             document_id,
             data_format=data_format,
@@ -145,9 +133,7 @@ class Find:  # pylint: disable=R0902
             sort="",
             data_format=None,
             type_num=None):
-        """
-        get the URL for the query view
-        """
+        """Build the URL for a query view."""
         if qtype not in self.query_types:
             self.logger.warning(
                 "Unknown query type '%s', falling back to 'default'.", qtype)
@@ -181,9 +167,7 @@ class Find:  # pylint: disable=R0902
             data_format=None,
             type_num=None,
             parser_class=None):
-        """
-        get query view
-        """
+        """Fetch and parse a query view."""
         url = self.url_query(
             query,
             qtype=qtype,
@@ -208,9 +192,7 @@ class Find:  # pylint: disable=R0902
             data_format=None,
             type_num=None,
             parser_class=None):
-        """
-        get query view via url
-        """
+        """Fetch and parse a query view from a full TYPO3-find URL."""
         url = self.url_parser(url)
         if url.is_ok:
             return self.get_query(
@@ -235,9 +217,7 @@ class Find:  # pylint: disable=R0902
             data_format="raw-solr-response",
             type_num=None,
             parser_class=None):
-        """
-        get all pages of a query view
-        """
+        """Fetch all pages of a query and return collected documents."""
         if batch <= 0:
             self.logger.warning("batch must be > 0; defaulting to 20")
             batch = 20
@@ -290,9 +270,7 @@ class Find:  # pylint: disable=R0902
             data_format="raw-solr-response",
             type_num=None,
             parser_class=None):
-        """
-        iterate all pages of a query view
-        """
+        """Yield documents from all pages of a query."""
         if batch <= 0:
             self.logger.warning("batch must be > 0; defaulting to 20")
             batch = 20

--- a/txpyfind/parser.py
+++ b/txpyfind/parser.py
@@ -1,17 +1,14 @@
-"""
-parser module of ``txpyfind`` package
-"""
+"""Response parsers for TYPO3-find JSON export formats."""
 import html
 import json
 import logging
 
 
 class JSONResponse:  # pylint: disable=R0903
-    """
-    ``JSONResponse`` class from ``txpyfind.parser`` module
-    """
+    """Base parser for JSON responses with HTML unescaping."""
 
     def __init__(self, plain):
+        """Parse a JSON string into a response object."""
         self.plain = plain
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         try:
@@ -22,6 +19,7 @@ class JSONResponse:  # pylint: disable=R0903
         self.fields = self._names(raw=self.raw)
 
     def _names(self, raw=None):
+        """Return top-level field names from parsed data."""
         if raw is None:
             raw = self.raw
         if isinstance(raw, dict):
@@ -29,6 +27,7 @@ class JSONResponse:  # pylint: disable=R0903
         return []
 
     def _field(self, name, raw=None):
+        """Return a field value with HTML unescaping."""
         if raw is None:
             raw = self.raw
         if isinstance(raw, dict) and name in raw:
@@ -36,6 +35,7 @@ class JSONResponse:  # pylint: disable=R0903
         return None
 
     def _unescape(self, value):
+        """HTML-unescape string or list-of-strings values."""
         if isinstance(value, str):
             return html.unescape(value.strip())
         if isinstance(value, list) and len(value) > 0 and \
@@ -70,10 +70,12 @@ class RawSolrResponse(JSONResponse):
 
     @property
     def facet_counts(self):
+        """Return the facet_counts field."""
         return self._field("facet_counts")
 
     @property
     def highlighting(self):
+        """Return the highlighting field."""
         return self._field("highlighting")
 
 
@@ -92,6 +94,7 @@ class SolrResultsResponse(JSONResponse):
 
     @property
     def docs(self):
+        """Return the list of documents."""
         if self.ok:
             return self.raw
         return []
@@ -112,4 +115,5 @@ class AllResponse(JSONResponse):
 
     @property
     def settings(self):
+        """Return the settings field."""
         return self._field("settings")

--- a/txpyfind/urlparse.py
+++ b/txpyfind/urlparse.py
@@ -1,6 +1,4 @@
-"""
-urlparse module of ``txpyfind`` package
-"""
+"""Extract TYPO3-find query parameters from URLs."""
 import re
 from urllib.parse import unquote_plus as unquote
 
@@ -14,11 +12,10 @@ SORT = re.compile(r"tx_find_find\[sort\]=([a-zA-Z0-9_]*)[+ ]([a-zA-Z0-9_]*)&?")
 
 
 class URLParser:  # pylint: disable=R0902,R0903
-    """
-    ``URLParser`` class from ``txpyfind.urlparse`` module
-    """
+    """Parse TYPO3-find query parameters from a URL."""
 
     def __init__(self, url):
+        """Parse TYPO3-find parameters from the given URL."""
         self.url = url
         self.query = ""
         self.qtype = ""
@@ -35,9 +32,7 @@ class URLParser:  # pylint: disable=R0902,R0903
 
 
 def preserve_ampersand(url):
-    """
-    preserve ampersand (``&``) in given URL
-    """
+    """Preserve ampersand in the given URL."""
     amps = QUERY_AMP.findall(url)
     if len(amps) == 1:
         url = url.replace(amps[0], amps[0].replace("%", SUBSTITUTE))
@@ -46,9 +41,7 @@ def preserve_ampersand(url):
 
 
 def find_query(url):
-    """
-    find query parameter in given URL
-    """
+    """Find query parameter in the given URL."""
     url, ampersand = preserve_ampersand(url)
     url = unquote(url)
     if ampersand:
@@ -59,37 +52,27 @@ def find_query(url):
 
 
 def find_facets(url):
-    """
-    find facet parameters in given URL
-    """
+    """Find facet parameters in the given URL."""
     return FACET.findall(unquote(url))
 
 
 def find_page(url):
-    """
-    find page parameter in given URL
-    """
+    """Find page parameter in the given URL."""
     return PAGE.findall(unquote(url))
 
 
 def find_count(url):
-    """
-    find count parameter in given URL
-    """
+    """Find count parameter in the given URL."""
     return COUNT.findall(unquote(url))
 
 
 def find_sort(url):
-    """
-    find sort parameter in given URL
-    """
+    """Find sort parameter in the given URL."""
     return SORT.findall(unquote(url))
 
 
 def get_query(url):
-    """
-    get query parameter from given URL
-    """
+    """Get query parameter from the given URL."""
     query = find_query(url)
     if len(query) == 1:
         qtype = query[0][0]
@@ -101,9 +84,7 @@ def get_query(url):
 
 
 def get_facets(url):
-    """
-    get facet parameters from given URL
-    """
+    """Get facet parameters from the given URL."""
     facets = find_facets(url)
     if len(facets) > 0:
         fct = []
@@ -114,9 +95,7 @@ def get_facets(url):
 
 
 def get_page(url):
-    """
-    get page parameter from given URL
-    """
+    """Get page parameter from the given URL."""
     page = find_page(url)
     if len(page) == 1:
         return int(page[0])
@@ -124,9 +103,7 @@ def get_page(url):
 
 
 def get_count(url):
-    """
-    get count parameter from given URL
-    """
+    """Get count parameter from the given URL."""
     count = find_count(url)
     if len(count) > 0:
         return int(count[0])
@@ -134,9 +111,7 @@ def get_count(url):
 
 
 def get_sort(url):
-    """
-    get sort parameter from given URL
-    """
+    """Get sort parameter from the given URL."""
     sort = find_sort(url)
     if len(sort) > 0:
         return f"{sort[0][0]} {sort[0][1]}"

--- a/txpyfind/utils.py
+++ b/txpyfind/utils.py
@@ -1,6 +1,4 @@
-"""
-utils module of ``txpyfind`` package
-"""
+"""URL construction and HTTP utilities for TYPO3-find."""
 import json
 import logging
 from urllib.error import URLError
@@ -14,9 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_request(url):
-    """
-    send HTTP GET request to given URL
-    """
+    """Send HTTP GET request to the given URL."""
     req = Request(url)
     req.add_header("User-Agent", f"txpyfind {__version__}")
     try:
@@ -30,9 +26,7 @@ def get_request(url):
 
 
 def plain_request(url):
-    """
-    request data in plain text format from given URL
-    """
+    """Request data in plain text format from the given URL."""
     payload = get_request(url)
     if isinstance(payload, bytes):
         try:
@@ -43,9 +37,7 @@ def plain_request(url):
 
 
 def json_request(url):
-    """
-    request data in JSON format from given URL
-    """
+    """Request data in JSON format from the given URL."""
     plain = plain_request(url)
     if isinstance(plain, str):
         try:
@@ -56,16 +48,12 @@ def json_request(url):
 
 
 def url_encode(url):
-    """
-    encode given URL
-    """
+    """URL-encode the given string."""
     return quote_plus(url)
 
 
 def set_param(url, key, value=None):
-    """
-    add initial parameter to given URL
-    """
+    """Add initial parameter to the given URL."""
     url = f"{url}?{key}"
     if value is not None:
         url = f"{url}={value}"
@@ -73,9 +61,7 @@ def set_param(url, key, value=None):
 
 
 def add_param(url, key, value=None):
-    """
-    add subsequent parameter to given URL
-    """
+    """Add subsequent parameter to the given URL."""
     url = f"{url}&{key}"
     if value is not None:
         url = f"{url}={value}"
@@ -83,9 +69,7 @@ def add_param(url, key, value=None):
 
 
 def tx_param(key, index=None):
-    """
-    create URL parameter for TYPO3-find
-    """
+    """Create a TYPO3-find URL parameter name."""
     if isinstance(key, str):
         k = f"[{key}]"
     else:
@@ -96,37 +80,27 @@ def tx_param(key, index=None):
 
 
 def set_tx_param(url, key, value, index=None):
-    """
-    add TYPO3-find parameter as initial parameter to given URL
-    """
+    """Add a TYPO3-find parameter as initial parameter to the given URL."""
     return set_param(url, tx_param(key, index=index), value)
 
 
 def add_tx_param(url, key, value, index=None):
-    """
-    add TYPO3-find parameter as subsequent parameter to given URL
-    """
+    """Add a TYPO3-find parameter as subsequent parameter to the given URL."""
     return add_param(url, tx_param(key,  index=index), value)
 
 
 def tx_param_data(data_format, type_num=1369315139):
-    """
-    create parameters for TYPO3-find data exports
-    """
+    """Create parameters for TYPO3-find data exports."""
     param = f"{tx_param('format')}=data"
     param = add_tx_param(param, "data-format", data_format)
     return add_param(param, "type", type_num)
 
 
 def set_tx_param_data(url, data_format, type_num=1369315139):
-    """
-    add parameters for TYPO3-find data exports as initial parameters to given URL
-    """
+    """Add TYPO3-find data export parameters as initial parameters to the given URL."""
     return set_param(url, tx_param_data(data_format, type_num=type_num))
 
 
 def add_tx_param_data(url, data_format, type_num=1369315139):
-    """
-    add parameters for TYPO3-find data exports as subsequent parameters to given URL
-    """
+    """Add TYPO3-find data export parameters as subsequent parameters to the given URL."""
     return add_param(url, tx_param_data(data_format, type_num=type_num))


### PR DESCRIPTION
## Summary
- Add `--plain` flag to print raw response text (query, document)
- Add `--parser` flag to load custom parser classes by dotted import path, or `none` to disable parsing
- Remove `--export-format` choices restriction on query subcommand
- Rewrite README intro, add plain output and custom parser sections with copy-friendly examples
- Normalize docstrings to single-line style across all modules, replace boilerplate with descriptions
- Update package description in pyproject.toml

## Test plan
- [x] `python -m pytest test/` — 23 tests pass
- [x] `--parser slubfind.parser.FincSolrResponse` — works with real slubfind class
- [x] `--parser slubfind.parser.FincSolrResults --export-format json-solr-results` — works
- [x] `--parser none` — returns raw response text without parsing
- [x] `--plain` — returns plain response text via parser
- [x] `python -m txpyfind --help` — shows new flags
- [x] `python -c "import txpyfind; print(txpyfind.__doc__)"` — updated docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)